### PR TITLE
Fix Filename cannot be empty error

### DIFF
--- a/src/Codeception/Module/FTP.php
+++ b/src/Codeception/Module/FTP.php
@@ -851,7 +851,7 @@ class FTP extends Filesystem
             $this->fail('failed to connect to ftp server');
         }
 
-        if (isset($this->config['key'])) {
+        if (!empty($this->config['key'])) {
             $keyFile = file_get_contents($this->config['key']);
 
             if (class_exists('Crypt_RSA')) {


### PR DESCRIPTION
Replaces https://github.com/Codeception/Codeception/pull/5442

> When the key field isn't set in suite configuration file,
it has the default empty string value and FTP module considers it as set and tries to load the file.
This issue can be fixed either by changing default value to null or by changing the code to consider empty string as not set.